### PR TITLE
Add base map layers from external config to main map and mapOrtho pages

### DIFF
--- a/apps/omar-app/grails-app/assets/javascripts/omar/list/list.controller.js
+++ b/apps/omar-app/grails-app/assets/javascripts/omar/list/list.controller.js
@@ -115,7 +115,7 @@
             // {{list.o2baseUrl}}/#{{list.o2contextPath}}/mapOrtho?layers={{image.properties.id}}
             //http://localhost/omar-app/omar/#/mapOrtho?layers=118
             vm.o2baseUrl = AppO2.APP_CONFIG.serverURL + '/omar';
-            console.log('vm.o2baseUrl: ', vm.o2baseUrl);
+            //console.log('vm.o2baseUrl: ', vm.o2baseUrl);
             //vm.o2contextPath = AppO2.APP_CONTEXTPATH;
 
             vm.displayFootprint = function(obj){

--- a/apps/omar-app/grails-app/assets/javascripts/omar/services/map.service.js
+++ b/apps/omar-app/grails-app/assets/javascripts/omar/services/map.service.js
@@ -7,14 +7,10 @@
     function mapService(wfsService) {
 
         // #################################################################################
-        // AppO2.APP_CONFIG is passed down from the .gsp, and is a global variable.  It 
+        // AppO2.APP_CONFIG is passed down from the .gsp, and is a global variable.  It
         // provides access to various client params in application.yml
         // #################################################################################
         //console.log('AppO2.APP_CONFIG in mapService: ', AppO2.APP_CONFIG);
-
-        // Add the basemap parameters from the applicaiton config file.
-        //var osmBaseMapUrl = APP_CONFIG.services.basemaps.osm.url;
-        //var osmBaseMapLayers = APP_CONFIG.services.basemaps.osm.layers;
 
         var zoomToLevel = 16;
         var map,
@@ -35,7 +31,7 @@
         var baseServerUrl = AppO2.APP_CONFIG.serverURL;
         var markerUrl = baseServerUrl + '/' + AppO2.APP_CONFIG.params.misc.icons.greenMarker;
 
-        console.log('marker: ', markerUrl);
+        //console.log('marker: ', markerUrl);
         iconStyle = new ol.style.Style({
             image: new ol.style.Icon(({
                 anchor: [0.5, 46],
@@ -111,56 +107,6 @@
                 maxZoom: 18
             });
 
-            //var baseMap = new ol.layer.Tile({
-            //    source: new ol.source.TileWMS({
-            //        url: osmBaseMapUrl,
-            //        params: {'LAYERS': osmBaseMapLayers, 'TILED': true},
-            //        serverType: 'geoserver'
-            //    }),
-            //    name: 'Open Street Map'
-            //});
-
-            //var baseMap = new ol.layer.Tile({
-            //     source: new ol.source.TileWMS({
-            //     url: 'http://vmap0.tiles.osgeo.org/wms/vmap0',
-            //         params: {
-            //            'VERSION': '1.1.1',
-            //            'LAYERS': 'basic,coastline_01,coastline_02,priroad,secroad,rail,ferry,tunnel,bridge,trail,CAUSE,clabel,statelabel,ctylabel',
-            //            'FORMAT': 'image/jpeg'
-            //        }
-            //    }),
-            //     name: 'baseMap'
-            //});
-
-            //var baseMap = new ol.layer.Tile({
-            //    source: new ol.source.OSM()
-            //});
-
-            //var baseMap = new ol.layer.Tile({
-            //    style: 'Road',
-            //    source: new ol.source.MapQuest({layer: 'osm'})
-            //});
-
-            //var baseMap = new ol.layer.Group({
-            //    style: 'AerialWithLabels',
-            //    visible: true,
-            //    layers: [
-            //        new ol.layer.Tile({
-            //            source: new ol.source.MapQuest({layer: 'sat'})
-            //        }),
-            //        new ol.layer.Tile({
-            //            source: new ol.source.MapQuest({layer: 'hyb'})
-            //        })
-            //    ]
-            //});
-
-             //var baseMap = new ol.layer.Tile({
-             //	source: new ol.source.XYZ({
-             //		url: 'http://54.174.83.202/osm/{z}/{x}/{y}.png'
-             //	}),
-             //	name: 'OSM XYZ'
-             //});
-
             footPrints = new ol.layer.Tile({
                 title: 'Image Footprints',
                 source: new ol.source.TileWMS({
@@ -176,34 +122,46 @@
                 name: 'Image Footprints'
             });
 
+            var baseMapGroup = new ol.layer.Group({
+                'title': 'Base maps',
+                layers: [
+                    //baseMap
+                ]
+            });
+
+            // Takes a map layer obj, and adds
+            // the layer to the map layers array.
+            function addBaseMapLayers(layerObj){
+
+              var baseMapLayer = new ol.layer.Tile({
+                  title: layerObj.layer.title,
+                  type: 'base',
+                  //visible: true,
+                  visible: layerObj.layer.options.visible,
+                  source: new ol.source.TileWMS({
+                      url: layerObj.layer.url,
+                      params: {
+                         'VERSION': '1.1.1',
+                         'LAYERS': layerObj.layer.params.layers,
+                         'FORMAT': layerObj.layer.params.format
+                     }
+                 }),
+                  name: layerObj.layer.title
+              });
+
+              // console.log('baseMapLayer: ', baseMapLayer);
+              // Add layer(s) to the layerSwitcher
+              baseMapGroup.getLayers().push(baseMapLayer);
+
+            }
+
+            // Map over each layer item in the layerList array
+            AppO2.APP_CONFIG.params.baseMaps.layerList.map(addBaseMapLayers);
+
             map = new ol.Map({
-                layers: /*[
-                    baseMap, footPrints
-                ], */
+                layers:
                     [
-                        new ol.layer.Group({
-                            'title': 'Base maps',
-                            layers: [
-                                new ol.layer.Tile({
-                                    title: 'OSM',
-                                    type: 'base',
-                                    visible: true,
-                                    source: new ol.source.OSM()
-                                }),
-                                new ol.layer.Tile({
-                                    title: 'Roads',
-                                    type: 'base',
-                                    visible: false,
-                                    source: new ol.source.MapQuest({layer: 'osm'})
-                                }),
-                                new ol.layer.Tile({
-                                    title: 'Satellite',
-                                    type: 'base',
-                                    visible: false,
-                                    source: new ol.source.MapQuest({layer: 'sat'})
-                                })
-                            ]
-                        }),
+                        baseMapGroup,
                         new ol.layer.Group({
                             title: 'Overlays',
                             layers: [
@@ -458,7 +416,7 @@
             content.innerHTML =
             '<div class="media">' +
                 '<div class="media-left">' +
-                    '<img class="media-object" ' + 
+                    '<img class="media-object" ' +
                         'src="' + baseServerUrl + '/imageSpace/getThumbnail?filename=' +
                         imageObj.properties.filename +
                         '&entry=' + imageObj.properties.entry_id +
@@ -702,4 +660,3 @@
     }
 
 }());
-

--- a/apps/omar-app/grails-app/assets/javascripts/omar/services/map.service.js
+++ b/apps/omar-app/grails-app/assets/javascripts/omar/services/map.service.js
@@ -125,7 +125,6 @@
             var baseMapGroup = new ol.layer.Group({
                 'title': 'Base maps',
                 layers: [
-                    //baseMap
                 ]
             });
 
@@ -136,7 +135,6 @@
               var baseMapLayer = new ol.layer.Tile({
                   title: layerObj.layer.title,
                   type: 'base',
-                  //visible: true,
                   visible: layerObj.layer.options.visible,
                   source: new ol.source.TileWMS({
                       url: layerObj.layer.url,

--- a/apps/omar-app/grails-app/conf/application.yml
+++ b/apps/omar-app/grails-app/conf/application.yml
@@ -544,26 +544,6 @@ wms:
               a: 255
 
 
-#web app configuration settings
-# webconfig:
-#   misc:
-#     icons:
-#       green-marker: search_marker_green.png
-#   services:
-#     proxy: /o2/proxy/index?url=
-#     omar:
-#       wfsUrl: http://localhost:7272/o2/wfs
-#       wmsUrl: http://localhost:8888/wms
-#       thumbnailsUrl: http://localhost:8888/omar/thumbnail/show/
-#       footprintsUrl: http://localhost:8888/omar/wms/footprints?
-#     twofishes:
-#       url: http://localhost:8081/twofish
-#       proxy: /o2/twoFishesProxy
-#     basemaps:
-#       osm:
-#         url: http://geoserver-demo01.dev.ossim.org/geoserver/ged/wms?
-#         layers: osm-group
-
 
 #server:
 #  contextPath: /o2
@@ -588,7 +568,7 @@ omar:
     wms:
       baseUrl: http://localhost:8080/wms?
       enabled: true
-    imageSpace: 
+    imageSpace:
       baseUrl: http://localhost:8080/imageSpace
       enabled: true
     thumbnails:
@@ -608,7 +588,6 @@ omar:
       baseUrl: http://localhost:8082/swipe
       enabled: true
     kmlApp:
-      #baseUrl: http://localhost:8282/
       baseUrl: http://localhost:8083/
       enabled: true
     jpipApp:
@@ -616,15 +595,37 @@ omar:
       enabled: false
     piwikApp:
       baseUrl: http://omar.ossim.org/piwik/
-      enabled: true  
+      enabled: true
     misc:
       icons:
         greenMarker: assets/search_marker_green.png
-#        greenmarker: search_marker_green.png
-#    basemaps:
-#      osm:
-#        baseUrl: http://geoserver-demo01.dev.ossim.org/geoserver/ged/wms?
-#        layers: osm-group
+    basemaps:
+      layerList:
+        - layer:
+            title: osm
+            url: http://geoserver-demo01.dev.ossim.org/geoserver/ged/wms?
+            params:
+              layers: basic,coastline_01,coastline_02,priroad,secroad,rail,ferry,tunnel,bridge,trail,CAUSE,clabel,statelabel,ctylabel
+              format: image/png
+            options:
+              # Default base layer is visible/on
+              visibile: true
+        - layer:
+            title: osm2
+            url: http://geoserver-demo01.dev.ossim.org/geoserver/ged/wms?
+            params:
+              layers: basic,coastline_01,coastline_02,priroad,secroad,rail,ferry,tunnel,bridge,trail,CAUSE,clabel,statelabel,ctylabel
+              format: image/png
+            options:
+              visibile: false
+        - layer:
+            title: osm3
+            url: http://geoserver-demo01.dev.ossim.org/geoserver/ged/wms?
+            params:
+              layers: basic,coastline_01,coastline_02,priroad,secroad,rail,ferry,tunnel,bridge,trail,CAUSE,clabel,statelabel,ctylabel
+              format: image/png
+            options:
+              visibile: false
 
 ---
 classificationBanner:
@@ -633,10 +634,9 @@ classificationBanner:
   #backgroundColor: red
   #classificationType: Secret // NOFORN
     # backgroundColor: yellow
-    # classificationType: Top Secret 
+    # classificationType: Top Secret
 
 
 ######### Example for External logback config settings in YAML
 # logging:
 #   config: <log back config location>
-

--- a/apps/omar-app/grails-app/conf/application.yml
+++ b/apps/omar-app/grails-app/conf/application.yml
@@ -599,33 +599,33 @@ omar:
     misc:
       icons:
         greenMarker: assets/search_marker_green.png
-    basemaps:
+    baseMaps:
       layerList:
         - layer:
-            title: osm
-            url: http://geoserver-demo01.dev.ossim.org/geoserver/ged/wms?
+            title: Open Street Map
+            url: http://vmap0.tiles.osgeo.org/wms/vmap0
             params:
               layers: basic,coastline_01,coastline_02,priroad,secroad,rail,ferry,tunnel,bridge,trail,CAUSE,clabel,statelabel,ctylabel
-              format: image/png
+              format: image/jpeg
             options:
               # Default base layer is visible/on
-              visibile: true
+              visible: true
         - layer:
-            title: osm2
-            url: http://geoserver-demo01.dev.ossim.org/geoserver/ged/wms?
+            title: Natural Earth
+            url: http://demo.boundlessgeo.com/geoserver/wms
             params:
-              layers: basic,coastline_01,coastline_02,priroad,secroad,rail,ferry,tunnel,bridge,trail,CAUSE,clabel,statelabel,ctylabel
-              format: image/png
+              layers: ne:NE1_HR_LC_SR_W_DR
+              format: image/jpeg
             options:
-              visibile: false
+              visible: false
         - layer:
-            title: osm3
-            url: http://geoserver-demo01.dev.ossim.org/geoserver/ged/wms?
+            title: Blue Marble
+            url: http://demo.opengeo.org/geoserver/wms
             params:
-              layers: basic,coastline_01,coastline_02,priroad,secroad,rail,ferry,tunnel,bridge,trail,CAUSE,clabel,statelabel,ctylabel
-              format: image/png
+              layers: nasa:bluemarble
+              format: image/jpeg
             options:
-              visibile: false
+              visible: false
 
 ---
 classificationBanner:

--- a/apps/omar-app/grails-app/conf/application.yml
+++ b/apps/omar-app/grails-app/conf/application.yml
@@ -608,8 +608,7 @@ omar:
               layers: basic,coastline_01,coastline_02,priroad,secroad,rail,ferry,tunnel,bridge,trail,CAUSE,clabel,statelabel,ctylabel
               format: image/jpeg
             options:
-              # Default base layer is visible/on
-              visible: true
+              visible: false
         - layer:
             title: Natural Earth
             url: http://demo.boundlessgeo.com/geoserver/wms
@@ -625,7 +624,7 @@ omar:
               layers: nasa:bluemarble
               format: image/jpeg
             options:
-              visible: false
+              visible: true
 
 ---
 classificationBanner:

--- a/apps/wmts-app/grails-app/assets/javascripts/wmts/map/wmts.map.controller.js
+++ b/apps/wmts-app/grails-app/assets/javascripts/wmts/map/wmts.map.controller.js
@@ -139,7 +139,6 @@
 
       function createWmtsOlLayer (layerName){
 
-        console.log('createWmtsOlLayer => layerName', layerName);
         // Create a new WMTS tile layer
         var wmtsLayer = new ol.layer.Tile({
           title: layerName,


### PR DESCRIPTION
This will add the base map layers from the external config (application.yml) to the application.  It does this for the main map, and for the mapOrtho page.  In addition, it adds a new layerswitcher control to the mapOrtho page. 
