### PR TITLE
OCS-743: Remove OL3 logo from map

### DIFF
--- a/apps/omar-app/grails-app/assets/javascripts/mapView.js
+++ b/apps/omar-app/grails-app/assets/javascripts/mapView.js
@@ -57,6 +57,7 @@ var MapView = (function ()
                 } )
             ] ),
             layers: layers,
+            logo: false,
             target: 'map',
             view: new ol.View( {
                 projection: 'EPSG:4326',

--- a/apps/omar-app/grails-app/assets/javascripts/omar/mapOrtho/map.ortho.controller.js
+++ b/apps/omar-app/grails-app/assets/javascripts/omar/mapOrtho/map.ortho.controller.js
@@ -301,6 +301,7 @@
                 new ol.control.ScaleLine()
             ] ).extend( [mousePositionControl] ),
             interactions: interactions,
+            logo: false,
             target: document.getElementById( 'mapOrtho' ),
             view: mapOrthoView
         } );

--- a/apps/omar-app/grails-app/assets/javascripts/omar/services/image-space.service.js
+++ b/apps/omar-app/grails-app/assets/javascripts/omar/services/image-space.service.js
@@ -308,6 +308,7 @@
                         source: source2
                     } )*/
                 ],
+                logo: false,
                 target: 'imageMap',
                 view: new ol.View( {
                     projection: proj,

--- a/apps/omar-app/grails-app/assets/javascripts/omar/services/map.service.js
+++ b/apps/omar-app/grails-app/assets/javascripts/omar/services/map.service.js
@@ -182,6 +182,7 @@
                     //new ol.control.FullScreen(),
                     new ol.control.ScaleLine()
                 ] ),
+                logo: false,
                 overlays: [overlay],
                 target: 'map',
                 view: mapView

--- a/apps/omar-app/grails-app/assets/stylesheets/styles.css
+++ b/apps/omar-app/grails-app/assets/stylesheets/styles.css
@@ -180,7 +180,7 @@ body {
 #mapDownloadButton{
     position: absolute;
     z-index: 1;
-    right: 40px;
+    right: 0.5em;
     bottom: 5px;
     margin-right: 10px;
 }


### PR DESCRIPTION
Removed the OL3 logo and moved the download button to the right.
