### PR TITLE
OCS-745: Map layer switcher and rotate buttons overlap

### DIFF
--- a/apps/omar-app/grails-app/assets/stylesheets/ol3-layerswitcher.css
+++ b/apps/omar-app/grails-app/assets/stylesheets/ol3-layerswitcher.css
@@ -8,7 +8,7 @@
 
 .layer-switcher {
     position: absolute;
-    top: 3.5em;
+    top: 2.5em;
     right: 0.5em;
     text-align: left;
     color: #000000;

--- a/apps/omar-app/grails-app/assets/stylesheets/styles.css
+++ b/apps/omar-app/grails-app/assets/stylesheets/styles.css
@@ -383,7 +383,7 @@ body {
     border-radius: 10px;
 }
 .ol-rotate {
-    top: 3em;
+    top: 4.5em;
 }
 
 .ol-popup {


### PR DESCRIPTION
Adjusted the CSS positions so the buttons don't interfere with one another.
