### PR TITLE
OCS-748: Mouse Coordinates Consolidation

### DIFF
--- a/apps/omar-app/grails-app/assets/javascripts/omar/mapOrtho/map.ortho.controller.js
+++ b/apps/omar-app/grails-app/assets/javascripts/omar/mapOrtho/map.ortho.controller.js
@@ -232,7 +232,7 @@
             undefinedHTML: '&nbsp;'
         } );
 	mousePositionControl.coordFormat = 0;
-        $(mousePositionControl.element).click(function() {
+        $('#mouseCoords').click(function() {
             mousePositionControl.coordFormat = mousePositionControl.coordFormat >= 2 ? 0 : mousePositionControl.coordFormat + 1;
         });
 


### PR DESCRIPTION
The coordinates weren't cycling in format because the clicks were not being captured. Needed to move the click listener to the actual div element that holds the readout.
