### PR TITLE
OCS-750: O2 DMS Coordinate Format

### DIFF
--- a/apps/omar-app/grails-app/assets/javascripts/omar/core/geopoint.js
+++ b/apps/omar-app/grails-app/assets/javascripts/omar/core/geopoint.js
@@ -49,26 +49,32 @@ GeoPoint.prototype = {
     latDeg: NaN,
 
     dec2deg: function(value, max, cardinal) {
-
         var sign = value < 0 ? -1 : 1;
 
         var abs = Math.abs(Math.round(value * 1000000));
 
         if (abs > (max * 1000000)) { return NaN; }
-
         var dec = abs % 1000000 / 1000000;
+
         var deg = Math.floor(abs / 1000000);
+        if (deg < 10) { deg = "0" + deg; }
+        if (max == this.MAX_LON && deg < 100) { deg = "0" + deg; }
+
         var min = Math.floor(dec * 60);
+        if (min < 10) { min = "0" + min; }
+
         var sec = (dec - min / 60) * 3600;
+        sec = sec.toFixed(2);
+        if (sec < 10) { sec = "0" + sec; }
 
         var result = "";
-
+        result += deg;
         result += this.CHAR_DEG;
         result += this.CHAR_SEP;
         result += min;
         result += this.CHAR_MIN;
         result += this.CHAR_SEP;
-        result += sec.toFixed(2);
+        result += sec;
         result += this.CHAR_SEC;
         if (cardinal) {
             var direction;
@@ -78,7 +84,7 @@ GeoPoint.prototype = {
             }
             result += " " + direction;
         }
-        else { result = (sign * deg) + result; }
+        else { result = (sign < 0 ? "-" : "") + result; }
 
         return result;
     },


### PR DESCRIPTION
Forced DMS to always have the same number of digits. e.g. DDMMSS.SS for latitude and DDDMMSS.SS for longitude.
